### PR TITLE
Remove use of soon to be deprecated function arguments 

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1040312'
+ValidationKey: '1060371'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrfactors: MADRaT based package on factor inputs'
-version: 0.5.2
-date-released: '2024-10-10'
+version: 0.5.3
+date-released: '2024-10-11'
 abstract: This package provides functions for MAgPIE input data on factor inputs to
   agricultural production (with a focus on capital and labor).
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrfactors
 Title: MADRaT based package on factor inputs
-Version: 0.5.2
-Date: 2024-10-10
+Version: 0.5.3
+Date: 2024-10-11
 Authors@R:
     c(person("Debbora", "Leip", , "leip@pik-potsdam.de", role = c("aut", "cre")),
       person("Edna", "Molina Bacca", role = "aut"))

--- a/R/calcAgEmplILO.R
+++ b/R/calcAgEmplILO.R
@@ -33,7 +33,7 @@ calcAgEmplILO <- function(subsectors = TRUE, inclFish = FALSE, inclForest = FALS
   subtype <- ifelse(dataVersionILO == "", "AgEmplShare", paste("AgEmplShare", dataVersionILO, sep = "_"))
   regCoeff <- readSource("RegressionsILO", subtype)
 
-  gdpPPPpc <- calcOutput("GDPpcPast", GDPpcPast = "WDI-MI", unit = "constant 2017 Int$PPP", aggregate = FALSE)
+  gdpPPPpc <- calcOutput("GDPpcPast", unit = "constant 2017 Int$PPP", aggregate = FALSE)
 
   estShare <- (regCoeff[, , "slope", drop = TRUE] * log10(gdpPPPpc) + regCoeff[, , "intercept", drop = TRUE]) ** 2
   const <- (regCoeff[, , "slope"] * log10(regCoeff[, , "threshold"]) + regCoeff[, , "intercept"]) ** 2

--- a/R/calcRegressionsILO.R
+++ b/R/calcRegressionsILO.R
@@ -33,11 +33,11 @@ calcRegressionsILO <- function(subtype = "AgEmplShare", dataVersionILO = "Aug24"
 
     if (subtype == "AgEmplShare") {
       description <- paste0("Regression coeffcients for sqrt(ag. empl. share) ~ log(GDP pc PPP, base = 10) ",
-                          "and a empl. share threshold")
+                            "and a empl. share threshold")
     } else if (subtype == "HourlyLaborCosts") {
       if (dataVersionILO == "") {
         description <- paste0("Regression coeffcients for hourly labor costs ~ GDP pc MER, ",
-                            "and a wage threshold")
+                              "and a wage threshold")
       } else {
         description <- "Regression coeffcients of pooled OLS for log(hourly labor costs) ~ log(GDP pc MER)"
       }
@@ -52,9 +52,9 @@ calcRegressionsILO <- function(subtype = "AgEmplShare", dataVersionILO = "Aug24"
   if (subtype == "AgEmplShare") {# Regression to fill missing countries in ILO ag. employment data set
 
     cat(paste0("Note: In case underlying data changed (agricultural employment from ILO, historic population,",
-                " or GDP pc PPP) you should double check the resulting regression."))
+               " or GDP pc PPP) you should double check the resulting regression."))
     description <- paste0("Regression coeffcients for sqrt(ag. empl. share) ~ log(GDP pc PPP, base = 10) ",
-                        "and a empl. share threshold")
+                          "and a empl. share threshold")
 
     # read original employment dataset from ILO (convert from thous. to mil.)
     dataType <- ifelse(dataVersionILO == "", "EmplByActivityModelled",
@@ -72,7 +72,7 @@ calcRegressionsILO <- function(subtype = "AgEmplShare", dataVersionILO = "Aug24"
     getNames(share) <- "share_empl_ag"
 
     # GDP per capita as independent variable (updated currency baseyear since Aug 24)
-    gdpPc <- calcOutput("GDPpcPast", GDPpcPast = "WDI-MI", unit = "constant 2017 Int$PPP", aggregate = FALSE)
+    gdpPc <- calcOutput("GDPpcPast", unit = "constant 2017 Int$PPP", aggregate = FALSE)
 
     years <- intersect(getYears(share), getYears(gdpPc))
     gdpPc <- gdpPc[, years, ]
@@ -119,11 +119,11 @@ calcRegressionsILO <- function(subtype = "AgEmplShare", dataVersionILO = "Aug24"
 
     # original hourly labor costs dataset (ILO data + data for India + data for China)
     hourlyLaborCosts <- calcOutput("HourlyLaborCosts", datasource = "ILO", dataVersionILO = dataVersionILO,
-                                  fillWithRegression = FALSE, aggregate = FALSE)
+                                   fillWithRegression = FALSE, aggregate = FALSE)
     hourlyLaborCosts[hourlyLaborCosts == 0] <- NA
 
     ## GDP PER CAPITA IN US$MER AS DEPENDENT VARIABLE (updated currency baseyear since Aug 24)
-    gdpPcMER <- calcOutput("GDPpcPast", GDPpcPast = "WDI-MI", unit = "constant 2017 US$MER", aggregate = FALSE)
+    gdpPcMER <- calcOutput("GDPpcPast", unit = "constant 2017 US$MER", aggregate = FALSE)
 
     ## combining data
     years <- intersect(getItems(hourlyLaborCosts, dim = 2), getItems(gdpPcMER, dim = 2))
@@ -144,19 +144,20 @@ calcRegressionsILO <- function(subtype = "AgEmplShare", dataVersionILO = "Aug24"
 
     if (wageRegrType == "linear") {
       if (thresholdWage != 0.1) warning(paste0("You changed the wage threshold. This option was included ",
-                                              "for testing purposes. Might lead to inconsistencies with ",
-                                              "functions using the default regression (e.g. calcLaborCosts ",
-                                              "or calcValidHourlyLaborCosts)"))
+                                               "for testing purposes. Might lead to inconsistencies with ",
+                                               "functions using the default regression (e.g. calcLaborCosts ",
+                                               "or calcValidHourlyLaborCosts)"))
 
-      if (isFALSE(forceWageIntercept)) warning(paste0("You changed the wage intercept setting. This option was ",
-                                              "included for testing purposes. Might lead to inconsistencies with ",
-                                              "functions using the default regression (e.g. calcLaborCosts ",
-                                              "or calcValidHourlyLaborCosts)"))
+      if (isFALSE(forceWageIntercept)) {
+        warning(paste0("You changed the wage intercept setting. This option was ",
+                       "included for testing purposes. Might lead to inconsistencies with ",
+                       "functions using the default regression (e.g. calcLaborCosts ",
+                       "or calcValidHourlyLaborCosts)"))
+      }
 
       cat(paste0("Note: In case underlying data changed (hourly labor costs from ILO, ",
-                  "or GDP pc MER) you should double check the resulting regression."))
-      description <- paste0("Regression coeffcients for hourly labor costs ~ GDP pc MER, ",
-                          "and a wage threshold")
+                 "or GDP pc MER) you should double check the resulting regression."))
+      description <- paste0("Regression coeffcients for hourly labor costs ~ GDP pc MER, and a wage threshold")
 
       # calculate regression (no regr weight, as we only have few countries and India would get too much influence)
       if (isTRUE(forceWageIntercept)) {
@@ -171,14 +172,14 @@ calcRegressionsILO <- function(subtype = "AgEmplShare", dataVersionILO = "Aug24"
 
       # create magclass object
       regCoeffs <- new.magpie(cells_and_regions = "GLO", names = c("intercept", "slope", "threshold"),
-                                            fill = NA, sets = c("region", "year", "data"))
+                              fill = NA, sets = c("region", "year", "data"))
       regCoeffs[, , "slope"] <- slope
       regCoeffs[, , "intercept"] <- intercept
       regCoeffs[, , "threshold"] <- thresholdWage
     } else {
       description <- "Regression coeffcients of pooled OLS for log(hourly labor costs) ~ log(GDP pc MER)"
       cat(paste0("Note: In case underlying data changed (hourly labor costs from ILO, ",
-                  "or GDP pc MER) you should double check the resulting regression."))
+                 "or GDP pc MER) you should double check the resulting regression."))
 
       reg <- lm(log(LaborCosts) ~ log(gdpPcMER), data = data)
       intercept <- reg$coefficients["(Intercept)"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MADRaT based package on factor inputs
 
-R package **mrfactors**, version **0.5.2**
+R package **mrfactors**, version **0.5.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrfactors)](https://cran.r-project.org/package=mrfactors)  [![R build status](https://github.com/pik-piam/mrfactors/workflows/check/badge.svg)](https://github.com/pik-piam/mrfactors/actions) [![codecov](https://codecov.io/gh/pik-piam/mrfactors/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrfactors) [![r-universe](https://pik-piam.r-universe.dev/badges/mrfactors)](https://pik-piam.r-universe.dev/builds)
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Debbora Leip <leip@pik-potsdam.de
 
 To cite package **mrfactors** in publications use:
 
-Leip D, Molina Bacca E (2024). _mrfactors: MADRaT based package on factor inputs_. R package version 0.5.2, <https://github.com/pik-piam/mrfactors>.
+Leip D, Molina Bacca E (2024). _mrfactors: MADRaT based package on factor inputs_. R package version 0.5.3, <https://github.com/pik-piam/mrfactors>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,7 +47,7 @@ A BibTeX entry for LaTeX users is
   title = {mrfactors: MADRaT based package on factor inputs},
   author = {Debbora Leip and Edna {Molina Bacca}},
   year = {2024},
-  note = {R package version 0.5.2},
+  note = {R package version 0.5.3},
   url = {https://github.com/pik-piam/mrfactors},
 }
 ```


### PR DESCRIPTION
The previous arguments were the default ones, so removing the explicit calls won't change anything yet. In the future, calcGDPpcPast will have an argument called "scenario", to retrieve the historic GDPpc data associated with one of the GDPpc scenarios, and, optional arguments to specify pas GDP and pop data. 

(Information on the sources is always available in the names / description fields).